### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
`python` changed recently. This pull request ensures you're using the latest version of the image and changes `python` to the latest tag: `3.11-alpine`

New base image: `python:3.11-alpine`